### PR TITLE
[seminar2] 과제 구현

### DIFF
--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'org.sopt'
@@ -9,7 +11,29 @@ repositories {
     mavenCentral()
 }
 
+java{
+    toolchain{
+        languageVersion=JavaLanguageVersion.of(17)
+    }
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir '/src/main/java'
+        }
+    }
+}
+
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.h2database:h2'
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/src/main/java/org/sopt/diary/DiaryApplication.java
+++ b/src/main/java/org/sopt/diary/DiaryApplication.java
@@ -1,0 +1,11 @@
+package org.sopt.diary;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DiaryApplication {
+    public static void main(String[] args){
+            SpringApplication.run(DiaryApplication.class);
+    }
+}

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -28,6 +28,16 @@ public class DiaryController {
         }
     }
 
+    @PatchMapping("/diary/{id}")
+    ResponseEntity<String> patch(@PathVariable long id, @RequestBody DiaryRequest request) {
+        try {
+            diaryService.updateDiary(id, request.getContent());
+            return ResponseEntity.ok("일기가 성공적으로 수정되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
     @GetMapping("/diaries")
     ResponseEntity<DiaryListResponse> getDiary() {
         // Service로부터 가져온 DiaryList
@@ -48,4 +58,5 @@ public class DiaryController {
         DiaryDetailResponse diaryResponseDetail = diaryService.getDiaryDetail(id);
         return ResponseEntity.ok(diaryResponseDetail);
     }
+
 }

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -3,10 +3,7 @@ package org.sopt.diary.api;
 import org.sopt.diary.service.Diary;
 import org.sopt.diary.service.DiaryService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +29,7 @@ public class DiaryController {
     }
 
     @GetMapping("/diaries")
-    ResponseEntity<DiaryListResponse> get() {
+    ResponseEntity<DiaryListResponse> getDiary() {
         // Service로부터 가져온 DiaryList
         List<Diary> diaryList = diaryService.getList();
 
@@ -43,5 +40,12 @@ public class DiaryController {
         }
 
         return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
+    }
+
+    // @PathVariable long id는 요청 URL에서 {id}를 추출하여 id 변수에 할당
+    @GetMapping("/diary/{id}")
+    ResponseEntity<DiaryDetailResponse> getDiaryDetail(@PathVariable long id){
+        DiaryDetailResponse diaryResponseDetail = diaryService.getDiaryDetail(id);
+        return ResponseEntity.ok(diaryResponseDetail);
     }
 }

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -38,6 +38,12 @@ public class DiaryController {
         }
     }
 
+    @DeleteMapping("/diary/{id}")
+    ResponseEntity<String> delete(@PathVariable long id){
+        diaryService.deleteDiary(id);
+        return ResponseEntity.ok("일기가 성공적으로 삭제되었습니다.");
+    }
+
     @GetMapping("/diaries")
     ResponseEntity<DiaryListResponse> getDiary() {
         // Service로부터 가져온 DiaryList

--- a/src/main/java/org/sopt/diary/api/DiaryController.java
+++ b/src/main/java/org/sopt/diary/api/DiaryController.java
@@ -1,0 +1,47 @@
+package org.sopt.diary.api;
+
+import org.sopt.diary.service.Diary;
+import org.sopt.diary.service.DiaryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+public class DiaryController {
+    private final DiaryService diaryService;
+
+    public DiaryController(DiaryService diaryService) {
+        this.diaryService = diaryService;
+    }
+
+    // ResponseEntity<String> 여기에서 <요기> 안에 들어가는 값에 대한 궁금증 발생!
+    // 여러 개의 필드(예: ID, 제목, 내용)를 함께 전달할 필요가 있다면 DiaryResponse와 같은 객체를 사용해야 함
+    @PostMapping("/diary")
+    ResponseEntity<String> post(@RequestBody DiaryRequest request) {
+        try {
+            diaryService.createDiary(request.getTitle(), request.getContent());
+            return ResponseEntity.ok("일기가 작성되었습니다.");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
+
+    @GetMapping("/diaries")
+    ResponseEntity<DiaryListResponse> get() {
+        // Service로부터 가져온 DiaryList
+        List<Diary> diaryList = diaryService.getList();
+
+        // Client 와 협의한 interface 로 변화
+        List<DiaryResponse> diaryResponseList = new ArrayList<>();
+        for(Diary diary : diaryList) {
+            diaryResponseList.add(new DiaryResponse(diary.getId(), diary.getTitle()));
+        }
+
+        return ResponseEntity.ok(new DiaryListResponse(diaryResponseList));
+    }
+}

--- a/src/main/java/org/sopt/diary/api/DiaryDetailResponse.java
+++ b/src/main/java/org/sopt/diary/api/DiaryDetailResponse.java
@@ -1,0 +1,42 @@
+package org.sopt.diary.api;
+
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DiaryDetailResponse {
+    private long id;
+    private String title;
+    private String content;
+    private String dateTime;
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    public static String formatTimestamp(LocalDateTime simpleDateTime) {
+        return simpleDateTime.format(FORMATTER);
+    }
+
+    public DiaryDetailResponse(long id, String title, String content, LocalDateTime dateTime){
+        this.id=id;
+        this.title=title;
+        this.content=content;
+        this.dateTime=formatTimestamp(dateTime);
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent(){
+        return content;
+    }
+
+    public String getDateTime(){
+        return dateTime;
+    }
+}

--- a/src/main/java/org/sopt/diary/api/DiaryListResponse.java
+++ b/src/main/java/org/sopt/diary/api/DiaryListResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.diary.api;
+
+import java.util.List;
+
+public class DiaryListResponse {
+    private List<DiaryResponse> diaryList;
+
+    public DiaryListResponse(List<DiaryResponse> diaryList) {
+        this.diaryList = diaryList;
+    }
+
+    public List<DiaryResponse> getDiaryList() {
+        return diaryList;
+    }
+}
+

--- a/src/main/java/org/sopt/diary/api/DiaryRequest.java
+++ b/src/main/java/org/sopt/diary/api/DiaryRequest.java
@@ -1,0 +1,24 @@
+package org.sopt.diary.api;
+
+//클라이언트 -> 서버 요청 : @RequestBody
+//서버 -> 클라이언트 응답 : @ResponseBody
+public class DiaryRequest {
+    private long id;
+    private String title;
+    private String content;
+
+    public DiaryRequest(){
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getTitle(){
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+}

--- a/src/main/java/org/sopt/diary/api/DiaryResponse.java
+++ b/src/main/java/org/sopt/diary/api/DiaryResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.diary.api;
+
+//클라이언트 -> 서버 요청 : @RequestBody
+//서버 -> 클라이언트 응답 : @ResponseBody
+public class DiaryResponse {
+    private long id;
+    private String title;
+
+    public DiaryResponse(long id, String title){
+        this.id=id;
+        this.title=title;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+}

--- a/src/main/java/org/sopt/diary/api/DiaryResponse.java
+++ b/src/main/java/org/sopt/diary/api/DiaryResponse.java
@@ -1,7 +1,9 @@
 package org.sopt.diary.api;
 
-//클라이언트 -> 서버 요청 : @RequestBody
-//서버 -> 클라이언트 응답 : @ResponseBody
+// 클라이언트 -> 서버 요청 : @RequestBody
+// 서버 -> 클라이언트 응답 : @ResponseBody
+// 여기서는 목록 list 사용자에게 보여줄 때만 이 파일 사용
+// 그래서 Content 변수 미포함
 public class DiaryResponse {
     private long id;
     private String title;

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -1,0 +1,39 @@
+package org.sopt.diary.repository;
+
+import jakarta.persistence.*;
+
+@Entity
+public class DiaryEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Long id;
+
+    // @Column 어노테이션은 객체 필드와 DB 테이블 컬럼을 맵핑
+    @Column
+    public String title;
+
+    @Column
+    public String content;
+
+    public DiaryEntity(){
+    }
+
+    public DiaryEntity(String title, String content){
+        this.title = title;
+        this.content = content;
+    }
+
+
+    public long getId() {
+        return id;
+    }
+
+
+    public String getTitle(){
+        return title;
+    }
+
+    public String getContent(){
+        return content;
+    }
+}

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -43,8 +43,15 @@ public class DiaryEntity {
         return title;
     }
 
+    // Getter (getContent)
+    // 역할: 객체의 필드 값을 가져와 보여줌
     public String getContent(){
         return content;
+    }
+    // Setter (setContent)
+    // 역할: 객체의 필드 값을 변경하는 메서드, 외부에서 객체의 상태를 변경하고 싶을 때 사용
+    public void setContent(String content) {
+        this.content = content;
     }
 
     public LocalDateTime getDateTime(){

--- a/src/main/java/org/sopt/diary/repository/DiaryEntity.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryEntity.java
@@ -2,6 +2,8 @@ package org.sopt.diary.repository;
 
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 public class DiaryEntity {
     @Id
@@ -15,6 +17,9 @@ public class DiaryEntity {
     @Column
     public String content;
 
+    @Column
+    public LocalDateTime dateTime;
+
     public DiaryEntity(){
     }
 
@@ -23,6 +28,11 @@ public class DiaryEntity {
         this.content = content;
     }
 
+    //사용자가 직접 날짜를 입력할 필요 없이, 저장 시점의 현재 시간을 기록
+    @PrePersist
+    protected void onCreate() {
+        this.dateTime = LocalDateTime.now();
+    }
 
     public long getId() {
         return id;
@@ -35,5 +45,9 @@ public class DiaryEntity {
 
     public String getContent(){
         return content;
+    }
+
+    public LocalDateTime getDateTime(){
+        return dateTime;
     }
 }

--- a/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -5,6 +5,14 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+// DiaryRepository는 데이터베이스와 통신하기 위한 데이터 액세스 계층
+// Spring Data JPA 덕분에 복잡한 SQL 작성 없이 CRUD 작업을 수행 가능
+// ex)
+// save(T entity): 엔티티를 데이터베이스에 저장(새로 생성 또는 수정)
+// findById(ID id): 특정 ID를 가진 엔티티 조회
+// findAll(): 모든 엔티티 조회
+// deleteById(ID id): 특정 ID를 가진 엔티티 삭제
+
 @Component
 public interface DiaryRepository extends JpaRepository<DiaryEntity,Long> {
     // id 필드를 기준으로 내림차순 정렬

--- a/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -1,0 +1,14 @@
+package org.sopt.diary.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public interface DiaryRepository extends JpaRepository<DiaryEntity,Long> {
+    // id 필드를 기준으로 내림차순 정렬
+    // Spring Data JPA에서는 메서드 이름에 조건을 명시함으로써 원하는 쿼리를 자동으로 생성
+    List<DiaryEntity> findTop10ByOrderByIdDesc();
+}

--- a/src/main/java/org/sopt/diary/repository/DiaryRepository.java
+++ b/src/main/java/org/sopt/diary/repository/DiaryRepository.java
@@ -1,7 +1,6 @@
 package org.sopt.diary.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,4 +10,8 @@ public interface DiaryRepository extends JpaRepository<DiaryEntity,Long> {
     // id 필드를 기준으로 내림차순 정렬
     // Spring Data JPA에서는 메서드 이름에 조건을 명시함으로써 원하는 쿼리를 자동으로 생성
     List<DiaryEntity> findTop10ByOrderByIdDesc();
+
+    DiaryEntity findById(long id);
 }
+
+

--- a/src/main/java/org/sopt/diary/service/Diary.java
+++ b/src/main/java/org/sopt/diary/service/Diary.java
@@ -1,0 +1,21 @@
+package org.sopt.diary.service;
+
+public class Diary {
+    private final long id;
+    private final String title;
+
+    public Diary(long id, String title){
+        this.id = id;
+        this.title = title;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+
+}

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -1,0 +1,41 @@
+package org.sopt.diary.service;
+
+import org.sopt.diary.repository.DiaryEntity;
+import org.sopt.diary.repository.DiaryRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class DiaryService {
+    private final DiaryRepository diaryRepository;
+
+    public DiaryService(DiaryRepository diaryRepository) {
+        this.diaryRepository = diaryRepository;
+    }
+
+    public void createDiary(String title, String content) {
+        if (content.length() > 30) {
+            throw new IllegalArgumentException("내용은 30자를 넘길 수 없습니다.");
+        }
+        diaryRepository.save(new DiaryEntity(title, content));
+    }
+
+    public List<Diary> getList() {
+        // (1) repository로 부터 DiaryEntity 를 가져옴
+        final List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByOrderByIdDesc();
+
+        // (2) DiaryEntity 를 Diary 로 변환해주는 작업
+        final List<Diary> diaryList = new ArrayList<>();
+
+        for(DiaryEntity diaryEntity : diaryEntityList){
+            diaryList.add(
+                new Diary(diaryEntity.getId(), diaryEntity.getTitle())
+            );
+        }
+
+        return diaryList;
+    }
+
+}

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -1,5 +1,6 @@
 package org.sopt.diary.service;
 
+import org.sopt.diary.api.DiaryDetailResponse;
 import org.sopt.diary.repository.DiaryEntity;
 import org.sopt.diary.repository.DiaryRepository;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,7 @@ public class DiaryService {
         this.diaryRepository = diaryRepository;
     }
 
+    // 반환 타입이 없기에 -> void
     public void createDiary(String title, String content) {
         if (content.length() > 30) {
             throw new IllegalArgumentException("내용은 30자를 넘길 수 없습니다.");
@@ -38,4 +40,9 @@ public class DiaryService {
         return diaryList;
     }
 
+    public DiaryDetailResponse getDiaryDetail(long id){
+        DiaryEntity diaryEntity = diaryRepository.findById(id);
+
+        return new DiaryDetailResponse(diaryEntity.getId(), diaryEntity.getTitle(), diaryEntity.getContent(), diaryEntity.getDateTime());
+    }
 }

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -33,6 +33,11 @@ public class DiaryService {
         diaryRepository.save(diaryEntity);
     }
 
+    public void deleteDiary(long id){
+        DiaryEntity diaryEntity = diaryRepository.findById(id);
+        diaryRepository.deleteById(id);
+    }
+
     public List<Diary> getList() {
         // (1) repository로 부터 DiaryEntity 를 가져옴
         final List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByOrderByIdDesc();

--- a/src/main/java/org/sopt/diary/service/DiaryService.java
+++ b/src/main/java/org/sopt/diary/service/DiaryService.java
@@ -24,6 +24,15 @@ public class DiaryService {
         diaryRepository.save(new DiaryEntity(title, content));
     }
 
+    public void updateDiary(long id, String content) {
+        DiaryEntity diaryEntity = diaryRepository.findById(id);
+        if (content.length() > 30) {
+            throw new IllegalArgumentException("내용은 30자를 넘길 수 없습니다.");
+        }
+        diaryEntity.setContent(content);
+        diaryRepository.save(diaryEntity);
+    }
+
     public List<Diary> getList() {
         // (1) repository로 부터 DiaryEntity 를 가져옴
         final List<DiaryEntity> diaryEntityList = diaryRepository.findTop10ByOrderByIdDesc();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,17 @@
+server:
+  port: 8081
+
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: chaehyun
+    password:
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create
+      dialect: org.hibernate.dialect.H2Dialect
+    properties:
+      format_sql: true
+      show_sql: true


### PR DESCRIPTION
## 🔥*Pull requests*


### 👷 **작업한 내용**

- [x] 일기 작성, 조회 기능 구현
- [x] 일기 상세 조회 기능 구현
- [x] 일기 수정 기능 구현
- [x] 일기 삭제 기능 구현

---
### **각 파일 역할 정리**
> `DiaryController`가 클라이언트의 요청을 받아 `DiaryService`를 호출해 비즈니스 로직을 처리하고, `DiaryRepository`를 통해 데이터베이스와 상호작용한다.

### 1. **DiaryService.java**
   - 일기 작성, 수정, 삭제, 조회 등 비즈니스 로직을 처리하는 서비스 계층

### 2. **Diary.java**
   - 일기 목록 조회 시 필요한 데이터 담고 있는 도메인 객체

### 3. **DiaryRepository.java**
   - 데이터베이스와 통신하는 역할

### 4. **DiaryEntity.java**
   - 데이터베이스와 1:1로 매핑되는 일기 엔티티
  
### 5. **DiaryResponse.java**
   - 일기 목록을 조회할 때 클라이언트에게 전달하는 응답 객체
 
### 6. **DiaryRequest.java**
   - 클라이언트가 일기 작성 또는 수정을 요청할 때 전달하는 요청 객체

### 7. **DiaryListResponse.java**
   - 일기 목록 조회 시 클라이언트에게 여러 개의 일기를 묶어서 전달하는 응답 객체

### 8. **DiaryDetailResponse.java**
   - 일기 상세 조회 시 클라이언트에게 전달하는 응답 객체
   
### 9. **DiaryController.java**
   -  HTTP 엔드포인터를 따라 처리하고, 서비스 계층과 통신하여 결과를 클라이언트에게 응답하는 역할

---
### **구현 내용**

**1.  일기 작성, 조회 기능**

> 조건이 들어가는 구현을 DiaryController 에서가 아닌 DiraryService에서 처리하도록 신경썼다.

DiaryRepository.java 구현 코드 중 일부

    public interface DiaryRepository extends JpaRepository<DiaryEntity, Long> {
    }

Spring Data JPA 덕분에 복잡한 SQL 작성 없이 CRUD 작업을 수행 가능한 것이 흥미로웠다.

- save(T entity): 엔티티를 데이터베이스에 저장(새로 생성 또는 수정)
- findById(ID id): 특정 ID를 가진 엔티티 조회
- findAll(): 모든 엔티티 조회
- deleteById(ID id): 특정 ID를 가진 엔티티 삭제
- **findTop10ByOrderByIdDesc() : 최신 순으로 10개 조회**

&nbsp;

**2. 일기 상세 조회 기능**

DiaryEntity.java 구현 코드 중 일부

<img src="https://github.com/user-attachments/assets/3cc8d47e-512a-42a9-beaa-a73b758f7a33" width="50%">

LocalDateTime이 모든 기능에 사용되는 것이 아니기에 Entity에 JPA Entity Lifecycle Callback 어노테이션을 사용해보았다.

- `@PrePersist`
**엔티티가 데이터베이스에 처음 저장되기 전에 해당 메서드를 자동으로 호출하여 실행하게 된다.**

**또 다른 종류**
- `@PrePersist` persist 호출 전 실행
- `@PostPersist` persist 호출 후 실행
- `@PreUpdate` update 호출 전 실행
- `@PostUpdate` update 호출 후 실행
- `@PreRemove` remove 호출 전 실행
- `@PostRemove` remove 호출 후 실행
- `@PostLoad` 엔티티가 로드된 직후 실행

&nbsp;

**3. 일기 수정 기능**

<img src="https://github.com/user-attachments/assets/a204a319-8b98-406f-b777-4ae094587a9a" width="50%">

setContent() 메서드로 내용을 업데이트한 뒤, diaryRepository.save(diaryEntity)를 호출하여 수정된 내용을 저장하는 방법을 선택했다.

<img src="https://github.com/user-attachments/assets/09a69d2b-433b-40bb-9f90-7db7110df9dd" width="50%">

- **Getter**:
  - **역할**: 클래스의 **필드 값을 반환**하여 외부에서 값을 읽을 수 있도록 한다.

- **Setter**:
  - **역할**: 클래스의 **필드 값을 변경**하여 외부에서 값을 수정할 수 있도록 한다.

-> 다른 필드(예: id, dateTime)는 작성 이후에 변경될 필요가 없으므로 Setter 없이 Getter만 제공하여 의도하지 않은 수정을 방어하는 방향으로 ! 

&nbsp;

**4. 일기 삭제 기능**

이번에도 Hard Delete 방식으로 구현하게 되었는데, 기획서에 "복구 기능이 없다" 라는 문구를 보고 삭제 구현 방향을 결정하게 되었다.  

---

모두들 수고 많았습니다! 🥇 

## 🚨 참고 사항
